### PR TITLE
Allow OAuth tokens for trading api

### DIFF
--- a/src/Trading/Services/TradingBaseService.php
+++ b/src/Trading/Services/TradingBaseService.php
@@ -17,6 +17,7 @@ class TradingBaseService extends \DTS\eBaySDK\Services\BaseService
     const HDR_DEV_ID = 'X-EBAY-API-DEV-NAME';
     const HDR_OPERATION_NAME = 'X-EBAY-API-CALL-NAME';
     const HDR_SITE_ID = 'X-EBAY-API-SITEID';
+	const HDR_API_TOKEN = 'X-EBAY-API-IAF-TOKEN';
 
     /**
      * @param array $config Configuration option values.
@@ -42,6 +43,9 @@ class TradingBaseService extends \DTS\eBaySDK\Services\BaseService
             'siteId' => [
                 'valid' => ['int', 'string'],
                 'required' => true
+            ],
+            'authorization' => [
+	            'valid' => ['string']
             ]
         ];
     }
@@ -63,7 +67,16 @@ class TradingBaseService extends \DTS\eBaySDK\Services\BaseService
         /**
          * Modify the request object to include the auth token that was set up in the configuration.
          */
-        if ($this->getConfig('authToken') !== null) {
+	    if ($this->getConfig('authorization') !== null) {
+		    /**
+		     * Don't send requester credentials if oauth authentication needed.
+		     */
+		    if (isset($request->RequesterCredentials)) {
+			    unset($request->RequesterCredentials);
+		    }
+
+	    }
+        elseif ($this->getConfig('authToken') !== null) {
             /**
              * Don't modify a request if the token already exists.
              */
@@ -111,6 +124,11 @@ class TradingBaseService extends \DTS\eBaySDK\Services\BaseService
         if ($devId) {
             $headers[self::HDR_DEV_ID] = $credentials->getDevId();
         }
+
+	    if ($this->getConfig('authorization') !== null)
+	    {
+		    $headers[self::HDR_API_TOKEN] = $this->getConfig('authorization');
+	    }
 
         return $headers;
     }


### PR DESCRIPTION
This PR allows making Trading API calls using the new OAuth token by setting the X-EBAY-API-IAF-TOKEN header and making sure no RequesterCredentials are sent.