### PR TITLE
Hotfix/incorrect item eligiblity types

### DIFF
--- a/src/PostOrder/Types/CancelSummary.php
+++ b/src/PostOrder/Types/CancelSummary.php
@@ -112,17 +112,17 @@ class CancelSummary extends \DTS\eBaySDK\Types\BaseType
             'attribute' => false,
             'elementName' => 'shipmentDate'
         ],
-        'state' => [
+        'cancelState' => [
             'type' => 'string',
             'repeatable' => false,
             'attribute' => false,
-            'elementName' => 'state'
+            'elementName' => 'cancelState'
         ],
-        'status' => [
+        'cancelStatus' => [
             'type' => 'string',
             'repeatable' => false,
             'attribute' => false,
-            'elementName' => 'status'
+            'elementName' => 'cancelStatus'
         ]
     ];
 

--- a/src/PostOrder/Types/ItemEligibilityResult.php
+++ b/src/PostOrder/Types/ItemEligibilityResult.php
@@ -36,13 +36,13 @@ class ItemEligibilityResult extends \DTS\eBaySDK\Types\BaseType
             'elementName' => 'failureReason'
         ],
         'itemId' => [
-            'type' => 'integer',
+            'type' => 'string',
             'repeatable' => false,
             'attribute' => false,
             'elementName' => 'itemId'
         ],
         'transactionId' => [
-            'type' => 'integer',
+            'type' => 'string',
             'repeatable' => false,
             'attribute' => false,
             'elementName' => 'transactionId'


### PR DESCRIPTION
Fix incorrect property types set in ItemEligibiltyResult causing a breaking bug when performing a checkCancellationEligibility call.

Property type changes:

itemId - changed from integer to string
transactionId - changed from integer to string