### PR TITLE
Added discountAmount property for Fulfillment\Types\GetOrdersRestResponse

### DIFF
--- a/src/Fulfillment/Types/DeliveryCost.php
+++ b/src/Fulfillment/Types/DeliveryCost.php
@@ -39,7 +39,14 @@ class DeliveryCost extends \DTS\eBaySDK\Types\BaseType
             'repeatable' => false,
             'attribute' => false,
             'elementName' => 'shippingIntermediationFee'
+        ],
+        'discountAmount' => [
+          'type' => 'DTS\eBaySDK\Fulfillment\Types\Amount',
+          'repeatable' => false,
+          'attribute' => false,
+          'elementName' => 'discountAmount'
         ]
+        
     ];
 
     /**


### PR DESCRIPTION
```php
<?php
use DTS\eBaySDK\Fulfillment\Types;
use DTS\eBaySDK\Fulfillment\Services;
use DTS\eBaySDK\Fulfillment\Types\GetOrdersRestRequest;

require_once __DIR__.'/vendor/autoload.php';

$token = "token";

$service = new Services\FulfillmentService([
  'authorization' => $token
]);

$request = new GetOrdersRestRequest();

$request->filter = "creationdate:[2017-04-27T08:25:43.511Z..]";

$response = $service->getOrders($request);

file_put_contents("test.json", json_encode($response->toArray(), JSON_PRETTY_PRINT));
```

brought me this:

    PHP Fatal error:  Uncaught DTS\eBaySDK\Exceptions\UnknownPropertyException: Unknown property discountAmount in /home/steven/Schreibtisch/eBayTrackingNumber/vendor/dts/ebay-sdk-php/src/Types/BaseType.php:464
    Stack trace:
    #0 /home/steven/Schreibtisch/eBayTrackingNumber/vendor/dts/ebay-sdk-php/src/Types/BaseType.php(309): DTS\eBaySDK\Types\BaseType::ensurePropertyExists('DTS\\eBaySDK\\Typ...', 'discountAmount')
    #1 /home/steven/Schreibtisch/eBayTrackingNumber/vendor/dts/ebay-sdk-php/src/Types/BaseType.php(276): DTS\eBaySDK\Types\BaseType->set('DTS\\eBaySDK\\Typ...', 'discountAmount', Array)
    #2 /home/steven/Schreibtisch/eBayTrackingNumber/vendor/dts/ebay-sdk-php/src/Types/BaseType.php(62): DTS\eBaySDK\Types\BaseType->setValues('DTS\\eBaySDK\\Typ...', Array)
    #3 /home/steven/Schreibtisch/eBayTrackingNumber/vendor/dts/ebay-sdk-php/src/Fulfillment/Types/DeliveryCost.php(58): DTS\eBaySDK\Types\BaseType->__construct(Array)
    #4 /home/steven/Schreibtisch/eBayTrackingNumber/vendor/dts/ebay-sdk-php/src/Types/BaseType.php(676): DTS\eBaySDK\Ful in /home/steven/Schreibtisch/eBayTrackingNumber/vendor/dts/ebay-sdk-php/src/Types/BaseType.php on line 464

adding the discountAmount property manually made it work for me.