### PR TITLE
fixed a bug in SDK not parsing GetMyeBaySellingRequestType response well.. after getting the response GalleryURL of PictureDetails was PictureURL instead

### DIFF
--- a/src/Trading/Types/PictureDetailsType.php
+++ b/src/Trading/Types/PictureDetailsType.php
@@ -40,11 +40,11 @@ class PictureDetailsType extends \DTS\eBaySDK\Types\BaseType
             'attribute' => false,
             'elementName' => 'PhotoDisplay'
         ],
-        'PictureURL' => [
+        'GalleryURL' => [
             'type' => 'string',
             'repeatable' => true,
             'attribute' => false,
-            'elementName' => 'PictureURL'
+            'elementName' => 'GalleryURL'
         ],
         'PictureSource' => [
             'type' => 'string',


### PR DESCRIPTION
Hey David!

I fixed a bug in SDK not parsing GetMyeBaySellingRequestType response well.. after getting the response GalleryURL of PictureDetails was PictureURL instead.

This problem resulted in me not able to get thumb images of products in my ActiveList.
Please mke sure though that I'm not affecting anything else as I'm not with full knowledge on the code of the SDK.

This is related to issue #113 I opened