### PR TITLE
Responsive OAuth Redirect URL

### DIFF
--- a/src/OAuth/Services/OAuthService.php
+++ b/src/OAuth/Services/OAuthService.php
@@ -177,8 +177,8 @@ class OAuthService
         }
 
         $url = $this->getConfig('sandbox')
-            ? 'https://signin.sandbox.ebay.com/authorize?'
-            : 'https://signin.ebay.com/authorize?';
+            ? 'https://auth.sandbox.ebay.com/oauth2/authorize?'
+            : 'https://auth.ebay.com/oauth2/authorize?';
 
         $urlParams = [
             'client_id'     => $this->getConfig('credentials')->getAppId(),

--- a/test/OAuth/Services/ServiceTest.php
+++ b/test/OAuth/Services/ServiceTest.php
@@ -71,7 +71,7 @@ class ServiceTest extends \PHPUnit_Framework_TestCase
             'ruName'      => 'baz',
             'sandbox'     => true
         ]);
-        $url = 'https://signin.sandbox.ebay.com/authorize?client_id=foo&redirect_uri=baz&response_type=code&state=111&scope=https%3A%2F%2Fapi.ebay.com%2Foauth%2Fapi_scope%2Fsell.account%20https%3A%2F%2Fapi.ebay.com%2Foauth%2Fapi_scope%2Fsell.inventory';
+        $url = 'https://auth.sandbox.ebay.com/oauth2/authorize?client_id=foo&redirect_uri=baz&response_type=code&state=111&scope=https%3A%2F%2Fapi.ebay.com%2Foauth%2Fapi_scope%2Fsell.account%20https%3A%2F%2Fapi.ebay.com%2Foauth%2Fapi_scope%2Fsell.inventory';
 
         $this->assertEquals($url, $s->redirectUrlForUser([
             'state'  => '111',
@@ -92,7 +92,7 @@ class ServiceTest extends \PHPUnit_Framework_TestCase
             ],
             'ruName'      => 'baz'
         ]);
-        $url = 'https://signin.ebay.com/authorize?client_id=foo&redirect_uri=baz&response_type=code&state=111&scope=https%3A%2F%2Fapi.ebay.com%2Foauth%2Fapi_scope%2Fsell.account%20https%3A%2F%2Fapi.ebay.com%2Foauth%2Fapi_scope%2Fsell.inventory';
+        $url = 'https://auth.ebay.com/oauth2/authorize?client_id=foo&redirect_uri=baz&response_type=code&state=111&scope=https%3A%2F%2Fapi.ebay.com%2Foauth%2Fapi_scope%2Fsell.account%20https%3A%2F%2Fapi.ebay.com%2Foauth%2Fapi_scope%2Fsell.inventory';
 
         $this->assertEquals($url, $s->redirectUrlForUser([
             'state'  => '111',


### PR DESCRIPTION
Responsive version of OAuth redirect URL provided by eBay to avoid error message on mobile devices. Fixes error "This can't be completed on a small screen, Please try again using a desktop computer instead."