### PR TITLE
Update for PHP 7.3 compatibility

### DIFF
--- a/src/Parser/XmlParser.php
+++ b/src/Parser/XmlParser.php
@@ -212,7 +212,7 @@ class XmlParser
                 case 'double':
                 case 'boolean':
                 case 'DateTime':
-                    continue;
+                    continue 2;
                 default:
                     return $meta->phpType !== '' ? new $phpType() : null;
             }
@@ -258,7 +258,7 @@ class XmlParser
                 case 'double':
                 case 'boolean':
                 case 'DateTime':
-                    continue;
+                    continue 2;
                 default:
                     return false;
             }


### PR DESCRIPTION
Changed `continue` to `continue 2` - see #241