### PR TITLE
Removed double quotes from Content-Type (boundary)

### DIFF
--- a/src/Trading/Services/TradingBaseService.php
+++ b/src/Trading/Services/TradingBaseService.php
@@ -160,7 +160,7 @@ class TradingBaseService extends \DTS\eBaySDK\Services\BaseService
          * Note that we have no way of detecting that the actual request has an attachment.
          */
         if ($operationName === 'UploadSiteHostedPictures') {
-            $headers['Content-Type'] = 'multipart/form-data;boundary="boundary"';
+            $headers['Content-Type'] = 'multipart/form-data;boundary=boundary';
         }
 
         return $headers;


### PR DESCRIPTION
Using a new production server with php 7.3 and nginx every time I made a call to UploadSiteHostedPictures an ack failure returns to me saying that the text inside xml is not valid. Removing the double quotes fix the problem to me and other developer