### PR TITLE
Use break instead of continue in switch statement

### DIFF
--- a/src/Parser/XmlParser.php
+++ b/src/Parser/XmlParser.php
@@ -212,7 +212,7 @@ class XmlParser
                 case 'double':
                 case 'boolean':
                 case 'DateTime':
-                    continue;
+                    break;
                 default:
                     return $meta->phpType !== '' ? new $phpType() : null;
             }


### PR DESCRIPTION
Using continue like this causes an error in strict mode: `"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?`