### PR TITLE
Fix warning in newer versions of php

### DIFF
--- a/src/Parser/XmlParser.php
+++ b/src/Parser/XmlParser.php
@@ -258,7 +258,7 @@ class XmlParser
                 case 'double':
                 case 'boolean':
                 case 'DateTime':
-                    continue;
+                    continue 2;
                 default:
                     return false;
             }


### PR DESCRIPTION
Fix warning (error in strict mode):  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?