### PR TITLE
Fix php 7.2 notice - replace wrong keyword in XmlParser

### DIFF
--- a/src/Parser/XmlParser.php
+++ b/src/Parser/XmlParser.php
@@ -212,7 +212,7 @@ class XmlParser
                 case 'double':
                 case 'boolean':
                 case 'DateTime':
-                    continue;
+                    break;
                 default:
                     return $meta->phpType !== '' ? new $phpType() : null;
             }

--- a/src/Parser/XmlParser.php
+++ b/src/Parser/XmlParser.php
@@ -258,7 +258,7 @@ class XmlParser
                 case 'double':
                 case 'boolean':
                 case 'DateTime':
-                    continue;
+                    break;
                 default:
                     return false;
             }


### PR DESCRIPTION
This exact keyword produces notice in php 7.2.
Changing continue to break(so we are going out of switch-case to foreach loop) solves the problem while leaving the same logic.